### PR TITLE
[FIX]管理画面の機能追加/#44

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'gon'
 gem 'material_kit', '~> 1.0', '>= 1.0.0.2'
 gem 'kaminari'
 gem 'rails_admin'
+gem 'cancan'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'chart-js-rails'
 gem 'gon'
 gem 'material_kit', '~> 1.0', '>= 1.0.0.2'
 gem 'kaminari'
+gem 'rails_admin'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,12 +86,17 @@ GEM
     faker (1.8.7)
       i18n (>= 0.7)
     ffi (1.9.23)
+    font-awesome-rails (4.7.0.4)
+      railties (>= 3.2, < 6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     gon (6.2.0)
       actionpack (>= 3.0)
       multi_json
       request_store (>= 1.0)
+    haml (5.0.4)
+      temple (>= 0.8.0)
+      tilt
     hpricot (0.8.6)
     html2slim (0.2.0)
       hpricot
@@ -104,6 +109,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -139,6 +146,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    nested_form (0.3.2)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -152,6 +160,9 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.3)
     rack (2.0.4)
+    rack-pjax (1.0.0)
+      nokogiri (~> 1.5)
+      rack (>= 1.1)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -174,6 +185,19 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
+    rails_admin (1.3.0)
+      builder (~> 3.1)
+      coffee-rails (~> 4.0)
+      font-awesome-rails (>= 3.0, < 5)
+      haml (>= 4.0, < 6)
+      jquery-rails (>= 3.0, < 5)
+      jquery-ui-rails (~> 5.0)
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rack-pjax (>= 0.7)
+      rails (>= 4.0, < 6)
+      remotipart (~> 1.3)
+      sass-rails (>= 4.0, < 6)
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.5)
     railties (5.1.6)
@@ -186,6 +210,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    remotipart (1.4.2)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)
@@ -279,6 +304,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.4)
   rails_12factor
+  rails_admin
   sass-rails (~> 5.0)
   selenium-webdriver
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.2)
+    cancan (1.6.10)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -286,6 +287,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   byebug
+  cancan
   capybara (~> 2.13)
   chart-js-rails
   coffee-rails (~> 4.2)

--- a/app/assets/stylesheets/block/_card.scss
+++ b/app/assets/stylesheets/block/_card.scss
@@ -1,0 +1,38 @@
+@import "../setting/all";
+
+.card-color {
+  border-left: 3px solid $color-primary-blue;
+}
+
+.card-text {
+  text-align: left;
+  padding: 10px;
+  word-wrap: break-word;
+}
+
+.bg-light {
+  background-color: $color-light-gray;
+}
+
+.card-body__wrap {
+  background: white;
+}
+
+.card-body__navi {
+  @include media_query_large_pc {
+    height: 75px;
+  }
+
+  @include media_query_pc {
+    height: 75px;
+  }
+
+  @include media_query_tablet {
+    height: 145px;
+  }
+
+  @include media_query_mobile {
+    height: 100px;
+  }
+}
+

--- a/app/assets/stylesheets/setting/_all.scss
+++ b/app/assets/stylesheets/setting/_all.scss
@@ -1,2 +1,3 @@
 @import "color";
+@import "media_query";
 @import "utility";

--- a/app/assets/stylesheets/setting/_media_query.scss
+++ b/app/assets/stylesheets/setting/_media_query.scss
@@ -1,0 +1,29 @@
+@mixin media_query_mobile {
+  @media (max-width:320px){
+    @content;
+  }
+}
+
+@mixin media_query_phablet {
+  @media (min-width: 320px) and (max-width: 768px){
+    @content;
+  }
+}
+
+@mixin media_query_tablet {
+  @media (min-width: 768px) and (max-width: 1024px){
+    @content;
+  }
+}
+
+@mixin media_query_pc {
+  @media (min-width: 1024px) and (max-width: 1366px){
+    @content;
+  }
+}
+
+@mixin media_query_large_pc {
+  @media (min-width: 1366px){
+    @content;
+  }
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,12 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
   before_action :set_post, only: %i[show]
-  before_action :set_form, only: %i[new]
+  before_action :set_form, only: %i[index new search_post]
   layout '_base'
 
   def index
-    @posts = Post.all
+    @posts = Post.all.page(params[:page])
+    @search_form = Post::SearchForm.new
   end
 
   def new
@@ -18,6 +19,12 @@ class PostsController < ApplicationController
     @search_form = School::SearchForm.new(search_params)
     @schools = @search_form.search.page(params[:page])
     render :new
+  end
+
+  def search_post
+    @search_form = Post::SearchForm.new(search_post_params)
+    @posts = @search_form.search.page(params[:page])
+    render :index
   end
 
   def show
@@ -41,10 +48,16 @@ class PostsController < ApplicationController
   end
 
   def set_form
+    @areas = ['関東地方','中部地方','北海道/東北地方','近畿地方','四国地方','中国地方','九州／沖縄地方','オンライン']
     @schools = School.all.page(params[:page])
+    @purposes = Purpose.all
   end
 
   def search_params
     params.require(:search).permit(:school_name, :purpose_name, :address_area, :skill_name)
+  end
+
+  def search_post_params
+    params.require(:search_post).permit(:school_name, :purpose_name, :skill_name)
   end
 end

--- a/app/forms/post/search_form.rb
+++ b/app/forms/post/search_form.rb
@@ -1,0 +1,34 @@
+class Post::SearchForm
+  include ActiveModel::Model
+
+  attr_accessor :school_name, :skill_name, :purpose_name, :address_area
+
+  def search
+    normalize_values
+    post_relation = Post
+
+    if school_name.present?
+      post_relation = post_relation.joins(:school)
+      post_relation = post_relation.where('schools.name LIKE(?)', "%#{school_name}%")
+    end
+
+    if purpose_name.present?
+      post_relation = post_relation.joins(:purposes)
+      post_relation = post_relation.where('purposes.name': purpose_name)
+    end
+
+    if skill_name.present?
+      post_relation = post_relation.joins(:skills)
+      post_relation = post_relation.where('skills.name LIKE(?)', "%#{skill_name}%")
+    end
+
+    post_relation = post_relation.distinct
+  end
+
+  private
+  def normalize_values
+    self.school_name = school_name
+    self.purpose_name = purpose_name
+    self.skill_name = skill_name
+  end
+end

--- a/app/forms/post/search_form.rb
+++ b/app/forms/post/search_form.rb
@@ -5,24 +5,24 @@ class Post::SearchForm
 
   def search
     normalize_values
-    post_relation = Post
+    post = Post
 
     if school_name.present?
-      post_relation = post_relation.joins(:school)
-      post_relation = post_relation.where('schools.name LIKE(?)', "%#{school_name}%")
+      post = post.joins(:school)
+      post = post.where('schools.name LIKE(?)', "%#{school_name}%")
     end
 
     if purpose_name.present?
-      post_relation = post_relation.joins(:purposes)
-      post_relation = post_relation.where('purposes.name': purpose_name)
+      post = post.joins(:purposes)
+      post = post.where('purposes.name': purpose_name)
     end
 
     if skill_name.present?
-      post_relation = post_relation.joins(:skills)
-      post_relation = post_relation.where('skills.name LIKE(?)', "%#{skill_name}%")
+      post = post.joins(:skills)
+      post = post.where('skills.name LIKE(?)', "%#{skill_name}%")
     end
 
-    post_relation = post_relation.distinct
+    post = post.distinct
   end
 
   private

--- a/app/forms/school/search_form.rb
+++ b/app/forms/school/search_form.rb
@@ -5,26 +5,26 @@ class School::SearchForm
 
   def search
     normalize_values
-    school_relation = School
-    school_relation = school_relation.where('schools.name LIKE(?)', "%#{school_name}%") if school_name.present?
+    school = School
+    school = school.where('schools.name LIKE(?)', "%#{school_name}%") if school_name.present?
 
     if address_area.present?
-      school_relation = school_relation.joins(:addresses)
-      school_relation = school_relation.where('addresses.area': address_area)
+      school = school.joins(:addresses)
+      school = school.where('addresses.area': address_area)
     end
 
     if purpose_name.present?
-      school_relation = school_relation.joins(:purposes)
-      school_relation = school_relation.where('purposes.name': purpose_name)
+      school = school.joins(:purposes)
+      school = school.where('purposes.name': purpose_name)
     end
 
     if skill_name.present?
-      school_relation = school_relation.joins(:skills)
-      school_relation = school_relation.where('skills.name LIKE(?)', "%#{skill_name}%")
+      school = school.joins(:skills)
+      school = school.where('skills.name LIKE(?)', "%#{skill_name}%")
     end
 
-    school_relation = school_relation.distinct
-    school_relation.order(:name)
+    school = school.distinct
+    school.order(:name)
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,31 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #user ||= User.new # guest user (not logged in)
+    if user && user.admin?
+      can :access, :rails_admin   # grant access to rails_admin
+      can :manage, :all           # allow superadmins to do anything
+    end
+    #
+    # The first argument to `can` is the action you are giving the user 
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on. 
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  end
+end

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,0 +1,29 @@
+.post-result
+  .post-result__header
+    h2
+      | 投稿一覧
+  .post-result__pagination
+    .post-result__pagination-info
+      = page_entries_info posts
+    .post-result__pagination-pagination
+      = paginate posts
+  .post-result__list
+    - posts.each do |post|
+      = link_to post_path(post.id) do
+        .card.bg-light.text-dark.card-color.mb-sm
+          .card-body
+            h4.card-title
+              .row
+                = post.user.name
+                | さん
+                br
+                = post.school.name
+                br
+                = post.course.name
+            p.card-text
+              = post.story.truncate(30)
+    .post-result__pagination
+      .post-result__pagination-info
+        = page_entries_info posts
+      .post-result__pagination-pagination
+        = paginate posts

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,0 +1,15 @@
+= simple_form_for search_form, as: 'search_post', url: :search_post_posts, html: { method: :get } do |f|
+  = f.label :school_name
+    | 学校名
+  = f.text_field :school_name, class: "form-control"
+  br
+  = f.label :purpose_name
+    | 目的
+  br
+  = f.collection_select :purpose_name, purposes, :name, :name, {include_blank: true}, class: "form-control"
+  br
+  = f.label :skill_name
+    | スキル
+  = f.text_field :skill_name, class: "form-control"
+  = button_tag type: 'submit', class: "square_btn" do
+    i.material-icons search この条件で検索する

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,19 +1,11 @@
-h1
-  | 投稿一覧を見る
-- @posts.each do |post|
-    p
-    = link_to post.user.name, post_path(post.id)
-    | さんの投稿
-    p
-    | 学んでいたプログラミングスクール:
-    = link_to post.school.name, school_path(post.school.id)
-    p
-    | 通っていたコース
-    = post.course.name
-    p
-    | ポートフォリオ:
-    = post.work
-    p
-    | 学んだことが役立ったエピソード:
-    = post.story
-    hr
+.container
+  .row
+    .col-md-4
+      h1
+        i.material-icons search
+        | 投稿を絞り込む
+      .form-search
+        = render 'search_form', { search_form: @search_form, purposes: @purposes }
+    .col-md-8
+      h2
+      = render 'post', { posts: @posts }

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,41 @@
+RailsAdmin.config do |config|
+
+  ### Popular gems integration
+
+  ## == Devise ==
+  # config.authenticate_with do
+  #   warden.authenticate! scope: :user
+  # end
+  # config.current_user_method(&:current_user)
+
+  ## == Cancan ==
+  # config.authorize_with :cancan
+
+  ## == Pundit ==
+  # config.authorize_with :pundit
+
+  ## == PaperTrail ==
+  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+
+  ### More at https://github.com/sferik/rails_admin/wiki/Base-configuration
+
+  ## == Gravatar integration ==
+  ## To disable Gravatar integration in Navigation Bar set to false
+  # config.show_gravatar = true
+
+  config.actions do
+    dashboard                     # mandatory
+    index                         # mandatory
+    new
+    export
+    bulk_delete
+    show
+    edit
+    delete
+    show_in_app
+
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -3,13 +3,13 @@ RailsAdmin.config do |config|
   ### Popular gems integration
 
   ## == Devise ==
-  # config.authenticate_with do
-  #   warden.authenticate! scope: :user
-  # end
-  # config.current_user_method(&:current_user)
+  config.authenticate_with do
+    warden.authenticate! scope: :user
+  end
+  config.current_user_method(&:current_user)
 
   ## == Cancan ==
-  # config.authorize_with :cancan
+  config.authorize_with :cancan
 
   ## == Pundit ==
   # config.authorize_with :pundit

--- a/config/locales/rails_admin.ja.yml
+++ b/config/locales/rails_admin.ja.yml
@@ -1,0 +1,129 @@
+ja:
+  admin:
+    home:
+      name: "ホーム"
+    pagination:
+      previous: "&laquo; 前"
+      next: "次 &raquo;"
+      truncate: "…"
+    misc:
+      filter_date_format: "yy/mm/dd" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
+      search: "検索"
+      filter: "検索"
+      refresh: "更新"
+      show_all: "すべて表示"
+      add_filter: "絞り込む..."
+      bulk_menu_title: "選択項目を..."
+      remove: "削除"
+      add_new: "新規作成"
+      chosen: "選択された%{name}"
+      chose_all: "すべて選択"
+      clear_all: "選択解除"
+      up: "上"
+      down: "下"
+      navigation: "ナビゲーション"
+      log_out: "ログアウト"
+      ago: "前"
+    flash:
+      successful: "%{name}の%{action}に成功しました"
+      error: "%{name}の%{action}に失敗しました"
+      noaction: "操作を取り消しました"
+      model_not_found: "モデル'%{model}'はありません"
+      object_not_found: "'ID:%{id}'の%{model}はありません"
+    table_headers:
+      model_name: "モデル名"
+      last_used: "最終アクセス日"
+      records: "レコード数"
+      username: "ユーザ"
+      changes: "変更"
+      created_at: "日時"
+      item: "アイテム"
+      message: "メッセージ"
+    actions:
+      dashboard:
+        title: "サイト管理"
+        menu: "ダッシュボード"
+        breadcrumb: "ダッシュボード"
+      index:
+        title: "%{model_label_plural}の一覧"
+        menu: "一覧"
+        breadcrumb: "%{model_label_plural}"
+      show:
+        title: "%{model_label} '%{object_label}'の詳細"
+        menu: "詳細"
+        breadcrumb: "%{object_label}"
+      show_in_app:
+        menu: "表示"
+      new:
+        title: "新規%{model_label}"
+        menu: "新規作成"
+        breadcrumb: "新規"
+        link: "新規%{model_label}追加"
+        done: "作成"
+      edit:
+        title: "%{model_label} '%{object_label}'を編集"
+        menu: "編集"
+        breadcrumb: "編集"
+        link: "この%{model_label}を編集"
+        done: "更新"
+      delete:
+        title: "%{model_label} '%{object_label}'を削除"
+        menu: "削除"
+        breadcrumb: "削除"
+        link: "'%{object_label}'削除"
+        done: "削除"
+      bulk_delete:
+        title: "%{model_label_plural}を一括削除"
+        menu: "一括削除"
+        breadcrumb: "一括削除"
+        bulk_link: "選択した%{model_label_plural}を削除"
+      export:
+        title: "%{model_label}をエクスポート"
+        menu: "エクスポート"
+        breadcrumb: "エクスポート"
+        link: "%{model_label_plural}をエクスポート"
+        bulk_link: "選択した%{model_label_plural}をエクスポート"
+        done: "エクスポート"
+      history_index:
+        title: "%{model_label_plural}の更新履歴"
+        menu: "履歴"
+        breadcrumb: "履歴"
+      history_show:
+        title: "%{model_label} '%{object_label}'の履歴"
+        menu: "履歴"
+        breadcrumb: "履歴"
+    form:
+      cancel: "キャンセル"
+      basic_info: "基本情報"
+      required: "必須"
+      optional: "オプション"
+      one_char: "文字"
+      char_length_up_to: "最大文字数:"
+      char_length_of: "文字数:"
+      save: "保存"
+      save_and_add_another: "保存して次へ"
+      save_and_edit: "保存して編集"
+      all_of_the_following_related_items_will_be_deleted: "を削除してよろしいですか? 以下の項目が削除され、もしくは関係を失います:"
+      are_you_sure_you_want_to_delete_the_object: "%{model_name}の項目"
+      confirmation: "実行する"
+      bulk_delete: "以下の項目が削除され、それによって関連する項目が削除され、もしくは関係を失います:"
+      new_model: "%{name} (新規)"
+    export:
+      confirmation: "%{name}としてエクスポート"
+      select: "エクスポートするフィールドを選択してください"
+      fields_from: "%{name}のフィールド"
+      fields_from_associated: "関連する%{name}のフィールド"
+      display: "カラム:%{name} 型:%{type}"
+      options_for: "%{name}の出力オプション"
+      empty_value_for_associated_objects: "<empty>"
+      click_to_reverse_selection: 'クリックで選択を反転します'
+      csv:
+        header_for_root_methods: "%{name}" # 'model' is available
+        header_for_association_methods: "%{name} [%{association}]"
+        encoding_to: "文字コード"
+        encoding_to_help: "空白の場合は%{name}になります"
+        skip_header: "ヘッダなし"
+        skip_header_help: "チェックすると出力にヘッダ行を含めません"
+        default_col_sep: ","
+        col_sep: "区切り文字"
+        col_sep_help: "空白の場合は'%{value}'区切りです" # value is default_col_sep

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'tops#index'
+
   devise_for :users
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   resources :users, only: %i[show]
 
   resources :schools, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :posts, only:[:index, :new, :show, :create, :destroy] do
     collection do
       get :search
+      get :search_post
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,16 +2,16 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'tops#index'
   devise_for :users
-  resources :users, only: [:show]
+  resources :users, only: %i[show]
 
-  resources :schools,only: [:index, :show] do
-    resources :posts, only:[:index, :new, :show, :create, :destroy], module: 'schools'
+  resources :schools, only: %i[index show] do
+    resources :posts, only: %i[index new show create destroy], module: 'schools'
     collection do
       get :search
     end
   end
 
-  resources :posts, only:[:index, :new, :show, :create, :destroy] do
+  resources :posts, only: %i[index new show create destroy] do
     collection do
       get :search
       get :search_post

--- a/db/migrate/20180531025723_add_admin_to_user.rb
+++ b/db/migrate/20180531025723_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180523071823) do
+ActiveRecord::Schema.define(version: 20180531025723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 20180523071823) do
     t.string "gender"
     t.text "history"
     t.text "future"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#44 
config/routes.rb
`mount RailsAdmin::Engine => '/admin', as: 'rails_admin`
がロケットハッシュになっているところが、気になっております。
調べてみたのですがシンボルでの書き方は、わかりませんでした。

- [x] rails_adminを導入する
- [x] rails_adminを日本語化する
- [x] cancanを導入する
- [x] Userモデルにadminカラムを設定する